### PR TITLE
u-boot-toradex-fw-utils: add new recipe

### DIFF
--- a/classes/image_torizon_tezi.bbclass
+++ b/classes/image_torizon_tezi.bbclass
@@ -1,2 +1,4 @@
 TEZI_ROOT_LABEL = "otaroot"
 TEZI_ROOT_SUFFIX = "ota-tar.xz"
+
+do_image_teziimg_distro[depends] += "u-boot-distro-boot-ostree:do_deploy"


### PR DESCRIPTION
The u-boot-fw-utils package is being installed in container images, so
we need let it built from same source with u-boot-toradex rather than
from the default u-boot-fw-utils, because we have specific uboot
configs based on u-boot-toradex, they might not present in the default
u-boot-fw-utils.

For instance, I observed a following build issue:
| ***
| *** Can't find default configuration "arch/../configs/colibri_imx7_emmc_defconfig"!
| ***
| scripts/kconfig/Makefile:128: recipe for target 'colibri_imx7_emmc_defconfig' failed

it's due to the colibri_imx7_emmc_defconfig does not exist in the
source.

To fix it, a new u-boot-toradex-fw-utils recipe is added, it uses the
same source with u-boot-toradex, some common code is split out to
u-boot-toradex-common.inc, to be shared by both u-boot-toradex and
u-boot-toradex-fw-utils.

And we need set PREFERRED_PROVIDER and PREFERRED_RPROVIDER in machine
configs to u-boot-toradex-fw-utils.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>