### PR TITLE
torizon.conf: drop ota from DISTROOVERRIDES

### DIFF
--- a/conf/distro/torizon.conf
+++ b/conf/distro/torizon.conf
@@ -3,7 +3,7 @@ require conf/distro/sota.conf.inc
 
 DISTRO = "torizon"
 DISTRO_NAME = "TorizonCore"
-DISTROOVERRIDES = "torizon:ota:"
+DISTROOVERRIDES = "torizon:"
 
 # SOTA
 OSTREE_OSNAME = "torizon"


### PR DESCRIPTION
ota could be a image base name in upstream meta-updater, so we could
not use it as a overrides any more, and it's actually not being
referred in nowhere, so should be safe to drop it.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>