### PR TITLE
lvm2: oe now refers to correct URI

### DIFF
--- a/recipes-support/lvm2/lvm2_%.bbappend
+++ b/recipes-support/lvm2/lvm2_%.bbappend
@@ -1,2 +1,0 @@
-SRC_URI_remove = "ftp://sources.redhat.com/pub/lvm2/LVM2.${PV}.tgz"
-SRC_URI_prepend = "ftp://sources.redhat.com/pub/lvm2/old/LVM2.${PV}.tgz "


### PR DESCRIPTION
- No need of bbappend as oe uses git://github.com/lvmteam/lvm2.git
- And also checks done using UPSTREAM_CHECK_URI at oe layer

Signed-off-by: Parthiban Nallathambi <pn@denx.de>